### PR TITLE
兼容 php  8.0

### DIFF
--- a/src/Collection.php
+++ b/src/Collection.php
@@ -515,7 +515,7 @@ class Collection implements ArrayAccess, Countable, IteratorAggregate, JsonSeria
             $fieldA = $a[$field] ?? null;
             $fieldB = $b[$field] ?? null;
 
-            return 'desc' == strtolower($order) ? $fieldB > $fieldA : $fieldA > $fieldB;
+            return 'desc' == strtolower($order) ? intval($fieldB > $fieldA) : intval($fieldA > $fieldB);
         });
     }
 


### PR DESCRIPTION
php 8.0使用数据集排序时会出现以下报错：
uasort(): Returning bool from comparison function is deprecated, return an integer less than, equal to, or greater than zero