### PR TITLE
增加查询表达式

### DIFF
--- a/src/Collection.php
+++ b/src/Collection.php
@@ -401,6 +401,10 @@ class Collection implements ArrayAccess, Countable, IteratorAggregate, JsonSeria
                 case 'not between':
                     [$min, $max] = is_string($value) ? explode(',', $value) : $value;
                     return is_scalar($result) && $result > $max || $result < $min;
+                case 'null':
+                    return $result === null;
+                case 'not null':
+                    return $result !== null;
                 case '==':
                 case '=':
                 default:


### PR DESCRIPTION
`===`和`!==`查询表达式不支持判断`null`，因为360行判断`$value`为`null`时，会更改查询表达式为`=`。 为了方便查询`null`的值，增加`null`和`not null`表达式